### PR TITLE
Change actions/checkout to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: macOS-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run tests
         run: xcodebuild test -project ColorKit/ColorKit.xcodeproj -scheme ColorKit -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 11"


### PR DESCRIPTION
To fix the warning we get when running workflows:
`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16`